### PR TITLE
feat(confirmModal): add modal to app

### DIFF
--- a/App.js
+++ b/App.js
@@ -18,15 +18,13 @@ import {
   SecureScreen
 } from './src/component';
 
-
-
 export default MainStack = StackNavigator({
+  DeActivateScreen: { screen: DeActivateScreen },
   SecureScreen: { screen: SecureScreen },
   LaunchScreen: { screen: LaunchScreen },
   LoginScreen: { screen: LoginScreen },
   SignUpScreen: { screen: SignUpScreen },
   EmptyScreen: { screen: EmptyScreen },
-  DeActivateScreen: { screen: DeActivateScreen },
   ActivateScreen: { screen: ActivateScreen },
   }, {
     navigationOptions: {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react": "16.0.0-alpha.12",
     "react-native": "^0.48.4",
     "react-native-easy-toast": "^1.0.8",
+    "react-native-simple-modal": "^7.0.0",
     "react-navigation": "^1.0.0-beta.15"
   }
 }

--- a/src/component/DeActivateScreen.js
+++ b/src/component/DeActivateScreen.js
@@ -1,17 +1,34 @@
+/* eslint-disable react/require-extension */
 // react libraries
 import React from 'react';
 
 // react-native libraries
 import { StyleSheet, View, Text, Image } from 'react-native';
 
+// third-party libraries
+import Modal from 'react-native-simple-modal';
+
 // common
-import { Button } from '../common';
+import { Button, Input } from '../common';
 
 export default class DeActivateScreen extends React.Component {
+  state = { showModal: false, password: '' };
 
   render() {
-    const { container, imageStyle, logoText, activeText, secureButton } = styles;
-    const { navigate } = this.props.navigation;
+    const {
+      container,
+      imageStyle,
+      logoText,
+      activeText,
+      secureButton,
+      confirmationTextStyle,
+      modalStyle,
+      modalPasswordView,
+      modalPasswordText,
+      modalBottomViewContainer,
+      modalCancelText,
+      modalDeActivateText
+    } = styles;
     return (
       <View style={container}>
         <Image
@@ -22,10 +39,49 @@ export default class DeActivateScreen extends React.Component {
         <Text style={activeText}>Blackbox is active</Text>
         <View style={secureButton}>
           <Button
-            onPress={() => { navigate('EmptyScreen'); }}
+            onPress={() => this.setState({ showModal: true })}
             text='DE-ACTIVATE'
           />
         </View>
+        <Modal
+          offset={this.state.offset}
+          open={this.state.showModal}
+          modalDidClose={() => this.setState({ showModal: false })}
+          style={modalStyle}
+        >
+          <View style={{ height: 168 }}>
+            <Text
+              style={confirmationTextStyle}
+            >
+              Confirmation
+            </Text>
+            <View
+              style={modalPasswordView}
+            >
+              <Input
+                secureTextEntry
+                style={modalPasswordText}
+                placeholder='Password'
+                value={this.state.password}
+                onChangeText={password => this.setState({ password })}
+              />
+            </View>
+            <View style={modalBottomViewContainer} >
+              <Text
+                style={modalCancelText}
+                onPress={() => this.setState({ showModal: false })}
+              >
+                CANCEL
+              </Text>
+              <Text
+                style={modalDeActivateText}
+                onPress={() => console.log(this.state.password)}
+              >
+                DE-ACTIVATE
+              </Text>
+            </View>
+          </View>
+        </Modal>
       </View>
     );
   }
@@ -44,7 +100,6 @@ const styles = StyleSheet.create({
   },
   logoText: {
     marginTop: 20,
-    fontWeight: '900',
     color: '#6e6e6e',
     fontFamily: 'Avenir-Heavy',
     fontSize: 25,
@@ -59,6 +114,44 @@ const styles = StyleSheet.create({
   },
   secureButton: {
     marginTop: 60,
+  },
+  modalStyle: {
+    alignItems: 'center'
+  },
+  confirmationTextStyle: {
+    fontFamily: 'Avenir-Heavy',
+    fontSize: 20,
+    marginTop: 10,
+    paddingLeft: 15,
+    color: '#616161',
+    fontWeight: '700'
+  },
+  modalPasswordView: {
+    marginTop: 21,
+    height: 33,
+    paddingLeft: 5,
+  },
+  modalPasswordText: {
+    fontFamily: 'Avenir-Book',
+    color: '#616161',
+  },
+  modalBottomViewContainer: {
+    flexDirection: 'row',
+    marginTop: 55,
+    marginLeft: 180
+  },
+  modalCancelText: {
+    flex: 1,
+    color: '#5c5c5c',
+    fontWeight: '700',
+    fontFamily: 'AvenirNextCondensed-Bold'
+  },
+  modalDeActivateText: {
+    flex: 2,
+    textAlign: 'right',
+    paddingRight: 10,
+    fontFamily: 'AvenirNextCondensed-Medium',
+    color: '#4a4a4a'
   }
 });
 

--- a/src/component/LoginScreen.js
+++ b/src/component/LoginScreen.js
@@ -1,31 +1,33 @@
+/* eslint-disable no-useless-escape,react/require-extension */
 // react libraries
 import React from 'react';
 
 // react-native libraries
-import { StyleSheet, View, Text, Image, TextVali } from 'react-native';
+import { StyleSheet, View, Text, Image } from 'react-native';
 
 // component
 import { Input, Button } from '../common';
 
 export default class LoginScreen extends React.Component {
-  state = { email: '', password: '', passwordErrorMessage: '', emailErrorMessage: ''}
+  state = { email: '', password: '', passwordErrorMessage: '', emailErrorMessage: '' }
 
   validateInput() {
     const { navigate } = this.props.navigation;
-    let re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-    if(!re.test(this.state.email)){
-      this.setState({ emailErrorMessage: 'Enter a valid email'})
+// eslint-disable-next-line max-len
+    const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    if (!re.test(this.state.email)) {
+      this.setState({ emailErrorMessage: 'Enter a valid email' });
     }
     if (this.state.password.length < 8) {
-      this.setState({ passwordErrorMessage: 'Password must be at least 8 characters'})
+      this.setState({ passwordErrorMessage: 'Password must be at least 8 characters' });
     }
-    if(re.test(this.state.email)) {
-      this.setState({emailErrorMessage: ''});
+    if (re.test(this.state.email)) {
+      this.setState({ emailErrorMessage: '' });
     }
     if (this.state.password.length > 7) {
-      this.setState({ passwordErrorMessage: ''})
+      this.setState({ passwordErrorMessage: '' });
     }
-    if(re.test(this.state.email) && this.state.password.length > 7) {
+    if (re.test(this.state.email) && this.state.password.length > 7) {
       navigate('EmptyScreen');
     }
   }
@@ -73,7 +75,7 @@ export default class LoginScreen extends React.Component {
         </View>
         <View style={loginButtonStyle}>
           <Button
-            onPress={() => {this.validateInput()}}
+            onPress={() => { this.validateInput(); }}
             text='LOGIN'
           />
         </View>
@@ -98,7 +100,6 @@ const styles = StyleSheet.create({
   },
   logoText: {
     paddingTop: 15,
-    fontWeight: '900',
     color: '#6e6e6e',
     fontFamily: 'Avenir-Heavy',
     fontSize: 29,
@@ -111,7 +112,7 @@ const styles = StyleSheet.create({
     width: 250,
     marginBottom: 15
   },
-  inputViewStyle2:{
+  inputViewStyle2: {
     height: 40,
     width: 250
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5062,9 +5062,19 @@ react-native-gesture-handler@1.0.0-alpha.22:
   dependencies:
     prop-types "^15.5.10"
 
+react-native-keyboard-spacer@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/react-native-keyboard-spacer/-/react-native-keyboard-spacer-0.4.1.tgz#46f18a320432098a25ea9fa89f5143dd254d332d"
+
 react-native-maps@0.15.3:
   version "0.15.3"
   resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-0.15.3.tgz#5d9e0a8e30ecc51dc755b7a3b9d6b6ed5e2dd08c"
+
+react-native-modal-wrapper@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-modal-wrapper/-/react-native-modal-wrapper-3.0.0.tgz#0d58b5a355d83af5428ed250f300e1088018f22a"
+  dependencies:
+    react-native-keyboard-spacer "^0.4.1"
 
 react-native-safe-module@^1.1.0:
   version "1.2.0"
@@ -5091,6 +5101,10 @@ react-native-scripts@1.5.0:
     qrcode-terminal "^0.11.0"
     rimraf "^2.6.1"
     xdl "45.0.0"
+
+react-native-simple-modal@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-simple-modal/-/react-native-simple-modal-7.0.0.tgz#402e4e51dd3c6a5f64b9cd8dfc0b364358fe956b"
 
 react-native-svg@5.3.0:
   version "5.3.0"


### PR DESCRIPTION
#### What Does This PR Do?
Implement de-activate screen modal

#### Description Of Task To Be Completed
As a user I should be able to see a modal when I click on the `DE-ACTIVATE` button

#### Any Background Context You Want To Provide?
N/A

#### How can this be manually tested?
* click on the de-activate button on the De-Active screen

#### Screenshot(s)
<img width="374" alt="screen shot 2017-10-30 at 10 36 57 am" src="https://user-images.githubusercontent.com/25608370/32163956-4fbf1482-bd5e-11e7-8d72-0734095504a3.png">


#### What are the relevant github issues?
N/A