### PR TITLE
feat(modal): add confirm activation modal

### DIFF
--- a/App.js
+++ b/App.js
@@ -21,11 +21,11 @@ import {
 export default MainStack = StackNavigator({
   DeActivateScreen: { screen: DeActivateScreen },
   SecureScreen: { screen: SecureScreen },
+  ActivateScreen: { screen: ActivateScreen },
   LaunchScreen: { screen: LaunchScreen },
   LoginScreen: { screen: LoginScreen },
   SignUpScreen: { screen: SignUpScreen },
   EmptyScreen: { screen: EmptyScreen },
-  ActivateScreen: { screen: ActivateScreen },
   }, {
     navigationOptions: {
       header: null

--- a/src/component/ActivateScreen.js
+++ b/src/component/ActivateScreen.js
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import { View, Text, StyleSheet, Image } from 'react-native';
 
 // common
-import { Strong, Button, LightButton } from '../common';
+import { Strong, LightButton } from '../common';
 
 class ActivateScreen extends Component {
   render() {

--- a/src/component/SecureScreen.js
+++ b/src/component/SecureScreen.js
@@ -4,12 +4,30 @@ import React, { Component } from 'react';
 // react-native library
 import { Image, StyleSheet, Text, View } from 'react-native';
 
+// third-party libraries
+import Modal from 'react-native-simple-modal';
+
 // button
-import { Button } from '../common';
+import { LightButton, Input } from '../common';
 
 class SecureScreen extends Component {
+  state = { showModal: false, password: '' };
+
   render() {
-    const { containerStyle, header, imageStyle, textStyle } = styles;
+    const {
+      containerStyle,
+      header,
+      imageStyle,
+      textStyle,
+      secureButton,
+      modalStyle,
+      confirmationTextStyle,
+      modalPasswordView,
+      modalPasswordText,
+      modalBottomViewContainer,
+      modalCancelText,
+      modalActivateText
+    } = styles;
     return (
       <View style={containerStyle}>
         <Image
@@ -18,12 +36,53 @@ class SecureScreen extends Component {
         />
         <Text style={header}>Your device is not secure</Text>
         <Text style={textStyle}>Blackbox is not active</Text>
-        <Button
-          onPress={() => console.log('HAHAHA!')}
-          text='ACTIVATE'
-        />
+        <View style={secureButton}>
+          <LightButton
+            onPress={() => this.setState({ showModal: true })}
+            text='ACTIVATE'
+          />
+        </View>
+        <Modal
+          offset={this.state.offset}
+          open={this.state.showModal}
+          modalDidClose={() => this.setState({ showModal: false })}
+          style={modalStyle}
+        >
+          <View style={{ height: 168 }}>
+            <Text
+              style={confirmationTextStyle}
+            >
+              Confirmation
+            </Text>
+            <View
+              style={modalPasswordView}
+            >
+              <Input
+                secureTextEntry
+                style={modalPasswordText}
+                placeholder='Password'
+                value={this.state.password}
+                onChangeText={password => this.setState({ password })}
+              />
+            </View>
+            <View style={modalBottomViewContainer} >
+              <Text
+                style={modalCancelText}
+                onPress={() => this.setState({ showModal: false })}
+              >
+                CANCEL
+              </Text>
+              <Text
+                style={modalActivateText}
+                onPress={() => console.log(this.state.password)}
+              >
+                ACTIVATE
+              </Text>
+            </View>
+          </View>
+        </Modal>
       </View>
-    )
+    );
   }
 }
 
@@ -52,6 +111,47 @@ const styles = StyleSheet.create({
     width: 90,
     alignSelf: 'center',
     margin: 30
+  },
+  secureButton: {
+    marginTop: 60,
+  },
+  modalStyle: {
+    alignItems: 'center'
+  },
+  confirmationTextStyle: {
+    fontFamily: 'Avenir-Heavy',
+    fontSize: 20,
+    marginTop: 10,
+    paddingLeft: 15,
+    color: '#616161',
+    fontWeight: '700'
+  },
+  modalPasswordView: {
+    marginTop: 21,
+    height: 33,
+    paddingLeft: 5,
+  },
+  modalPasswordText: {
+    fontFamily: 'Avenir-Book',
+    color: '#616161',
+  },
+  modalBottomViewContainer: {
+    flexDirection: 'row',
+    marginTop: 55,
+    marginLeft: 180
+  },
+  modalCancelText: {
+    flex: 1,
+    color: '#5c5c5c',
+    fontWeight: '700',
+    fontFamily: 'AvenirNextCondensed-Bold'
+  },
+  modalActivateText: {
+    flex: 2,
+    textAlign: 'right',
+    paddingRight: 10,
+    fontFamily: 'AvenirNextCondensed-Medium',
+    color: '#4a4a4a'
   }
 });
 


### PR DESCRIPTION
#### What Does This PR Do?
Implement activate screen modal

#### Description Of Task To Be Completed
As a user I should be able to see a modal when I cSick on the `ACTIVATE` button

#### Any Background Context You Want To Provide?
N/A

#### How can this be manually tested?
* click on the `ACTIVATE` button on the Secure-Screen

#### Screenshot(s)
<img width="373" alt="screen shot 2017-10-30 at 11 30 33 am" src="https://user-images.githubusercontent.com/25608370/32166330-c9e32ee0-bd65-11e7-9e54-19124279131a.png">

#### What are the relevant github issues?
N/A